### PR TITLE
Switch to Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,21 @@
-FROM ubuntu:14.04
+FROM alpine:3.4
 
-RUN apt-get update && \
-    apt-get install -y python-pip cron
+ARG CURATOR_VERSION=4.2.1
 
-ENV CURATOR_VERSION 4.2.1
-RUN pip install --quiet elasticsearch-curator==${CURATOR_VERSION}
+RUN \
+  apk add --no-cache --update \
+    bash \
+    python \
+    py-pip \
+    sed \
+    && \
+  pip install --no-cache-dir \
+    elasticsearch-curator==${CURATOR_VERSION} \
+    && \
+  mkdir /actions /config
 
-RUN mkdir /actions /config
-ADD crontab /etc/crontab
-ADD templates/* /templates/
+COPY crontab /var/spool/cron/crontabs/root
+COPY templates/* /templates/
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
-ADD run.sh /usr/bin/run.sh
-
-ENTRYPOINT "/usr/bin/run.sh"
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/crontab
+++ b/crontab
@@ -1,2 +1,2 @@
 # Write out status every five minutes to ensure curator is working as expected
-*/5 * * * * root echo "curator running on $(hostname)" >> /var/log/cron.log 2>&1
+*/5 * * * * echo "curator running on $(hostname)" >> /dev/stdout

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,7 +8,7 @@ if [ -n "$CLOSE_HOUR" ]; then
   sed 's/{{ACTION}}/close/g' |
   sed 's/{{HOUR}}/'"${CLOSE_HOUR:-8}"'/g' |
   sed 's/{{MINUTE}}/'"${CLOSE_MINUTE:-0}"'/g' |
-  cat >> /etc/crontab
+  cat >> /var/spool/cron/crontabs/root
 
   cat /templates/close.yml |
   sed 's/{{CLOSE_DAY}}/'"${CLOSE_DAY:-7}"'/g' |
@@ -20,7 +20,7 @@ if [ -n "$DELETE_HOUR" ]; then
   sed 's/{{ACTION}}/delete/g' |
   sed 's/{{HOUR}}/'"${DELETE_HOUR:-9}"'/g' |
   sed 's/{{MINUTE}}/'"${DELETE_MINUTE:-0}"'/g' |
-  cat >> /etc/crontab
+  cat >> /var/spool/cron/crontabs/root
 
   cat /templates/delete.yml |
   sed 's/{{DELETE_DAY}}/'"${DELETE_DAY:-8}"'/g' |
@@ -32,7 +32,7 @@ if [ -n "$SNAPSHOT_HOUR" ] && [ -n "$SNAPSHOT_REPOSITORY" ]; then
   sed 's/{{ACTION}}/snapshot/g' |
   sed 's/{{HOUR}}/'"${SNAPSHOT_HOUR:-10}"'/g' |
   sed 's/{{MINUTE}}/'"${SNAPSHOT_MINUTE:-0}"'/g' |
-  cat >> /etc/crontab
+  cat >> /var/spool/cron/crontabs/root
 
   cat /templates/snapshot.yml |
   sed 's/{{SNAPSHOT_FROM_DAY}}/'"${SNAPSHOT_FROM_DAY:-2}"'/g' |
@@ -47,7 +47,7 @@ if [ -n "$FORCEMERGE_HOUR" ]; then
   sed 's/{{ACTION}}/forcemerge/g' |
   sed 's/{{HOUR}}/'"${FORCEMERGE_HOUR:-11}"'/g' |
   sed 's/{{MINUTE}}/'"${FORCEMERGE_MINUTE:-0}"'/g' |
-  cat >> /etc/crontab
+  cat >> /var/spool/cron/crontabs/root
 
   cat /templates/forcemerge.yml |
   sed 's/{{FORCEMERGE_DELAY}}/'"${FORCEMERGE_DELAY:-120}"'/g' |
@@ -65,8 +65,4 @@ sed 's/{{MASTER_ONLY}}/'"${MASTER_ONLY:-False}"'/g' |
 sed 's/{{SSL}}/'"${SSL:-False}"'/g' |
 cat > /config/config.yml
 
-touch /var/log/cron.log
-
-cron
-
-tail -qf /var/log/cron.log
+exec crond -l 2 -f

--- a/templates/cron
+++ b/templates/cron
@@ -1,1 +1,1 @@
-0 {{HOUR}} * * * root /usr/local/bin/curator --config /config/config.yml /actions/{{ACTION}}.yml >> /var/log/cron.log 2>&1
+{{MINUTE}} {{HOUR}} * * * /usr/bin/curator --config /config/config.yml /actions/{{ACTION}}.yml >> /dev/stdout 2>&1


### PR DESCRIPTION
Reduces image size by 85%:

```
docker images lukedemi/curator
REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
lukedemi/curator    alpine              34982a62df2a        About a minute ago   55.52 MB
lukedemi/curator    latest              263a7610e03f        3 days ago           360.8 MB
```

Other adjustments:
* Adds the missing `{{MINUTE}}` from cron template
* Switches CURATOR_VERSION from ENV to ARG (so you don't have to modify Dockerfile each new version)
* Renames run.sh to docker-entrypoint.sh to match Docker's convention. e.g. https://github.com/docker-library/mysql/blob/master/8.0/docker-entrypoint.sh

Seemingly works just like before (I'm not running ES locally so it errors as expected):

```
docker run -it --rm -e CLOSE_HOUR=\* -e CLOSE_MINUTE=\* lukedemi/curator:alpine
crond[1]: crond (busybox 1.24.2) started, log level 2
crond[1]: user:root entry:*/5 * * * * echo "curator running on $(hostname)" >> /dev/stdout
crond[1]: user:root entry:* * * * * /usr/bin/curator --config /config/config.yml /actions/close.yml >> /dev/stdout 2>&1
crond[1]: user:root entry:*/5 * * * * echo "curator running on $(hostname)" >> /dev/stdout
crond[1]: user:root entry:* * * * * /usr/bin/curator --config /config/config.yml /actions/close.yml >> /dev/stdout 2>&1
crond[1]: wakeup dt=27
crond[1]: file root:
crond[1]:  line echo "curator running on $(hostname)" >> /dev/stdout
crond[1]:  line /usr/bin/curator --config /config/config.yml /actions/close.yml >> /dev/stdout 2>&1
crond[1]:  job: 0 /usr/bin/curator --config /config/config.yml /actions/close.yml >> /dev/stdout 2>&1
crond[23]: child running /bin/sh
crond[1]: USER root pid  23 cmd /usr/bin/curator --config /config/config.yml /actions/close.yml >> /dev/stdout 2>&1
{"@timestamp": "2016-11-23T23:34:00.614Z", "function": "cli", "linenum": 151, "loglevel": "INFO", "message": "Preparing Action ID: 1, \"close\"", "name": "curator.cli"}
Traceback (most recent call last):
  File "/usr/bin/curator", line 9, in <module>
    load_entry_point('elasticsearch-curator==4.2.1', 'console_scripts', 'curator')()
  File "/usr/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/curator/cli.py", line 166, in cli
    client = get_client(**client_args)
  File "/usr/lib/python2.7/site-packages/curator/utils.py", line 587, in get_client
    'Error: {0}'.format(e)
elasticsearch.exceptions.ElasticsearchException: Unable to create client connection to Elasticsearch.  Error: ConnectionError(<urllib3.connection.HTTPConnection object at 0x7f0aa48bb290>: Failed to establish a new connection: [Errno 111] Connection refused) caused by: NewConnectionError(<urllib3.connection.HTTPConnection object at 0x7f0aa48bb290>: Failed to establish a new connection: [Errno 111] Connection refused)
crond[1]: wakeup dt=10
```
